### PR TITLE
fix function pointer for arena once if the memory layout is changed before pool_open

### DIFF
--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -1736,6 +1736,15 @@ pool_open(pool_t *pool, size_t size, unsigned pool_id)
 	pools[pool_id] = pool;
 	npools_cnt++;
 
+	unsigned i;
+	for (i = 0; i < pool->narenas_total; ++i) {
+		arena_t *arena = pool->arenas[i];
+		if (arena != NULL) {
+			arena->chunk_alloc = chunk_alloc_default;
+			arena->chunk_dalloc = chunk_dalloc_default;
+		}
+	}
+
 	return pool;
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Initialize two function pointer field of `arena`, like `chunk_alloc` and `chunk_dalloc`,  when we call `pool_open` to open an existed memory pool which type is `pool_t`.

### Why are the changes needed?
As we know, function is located in `.text` section of linux ELF file. If the code lines are changed, memory layout of `.text` section and those function's address will changed. The old function pointer of `chunk_dalloc` will point at another function like `chunk_unmap`, and it will lead to core dump(segment fault).

![Lark20200118-183910](https://user-images.githubusercontent.com/763168/72662423-e051a400-3a21-11ea-9d82-e3879f068c87.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmem/12)
<!-- Reviewable:end -->
