### PR TITLE
common: expect the correct return value from getrandom()

### DIFF
--- a/src/common/rand.c
+++ b/src/common/rand.c
@@ -113,8 +113,10 @@ randomize_r(rng_t *state, uint64_t seed)
 	if (!seed) {
 #ifdef SYS_getrandom
 		/* We want getentropy() but ancient Red Hat lacks it. */
-		if (!syscall(SYS_getrandom, state, sizeof(rng_t), 0))
+		if (syscall(SYS_getrandom, state, sizeof(rng_t), 0)
+			== sizeof(rng_t)) {
 			return; /* nofail, but ENOSYS on kernel < 3.16 */
+		}
 #elif _WIN32
 #pragma comment(lib, "Bcrypt.lib")
 		if (BCryptGenRandom(NULL, (PUCHAR)state, sizeof(rng_t),


### PR DESCRIPTION
During development, this was getentropy() which returns 0 on success
rather than number of bytes copied.  The wrong expectation results in
fallback to bad randomness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/vmem/19)
<!-- Reviewable:end -->
